### PR TITLE
Add preliminary support for ignored files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,19 @@ can stage or unstage files from the index simply by changing their status:
   add FILE`.
 * To stop tracking of a file, change its status to `?`. This runs `git rm
   --cached FILE`.
-* To delete an untracked file, remove the line with the file. This deletes the
-  file by using the operating system's file-deletion facilities.
+* To add an ignored file, change its status from `!` to `A`. This runs `git add
+  -f FILE`.
+* To delete an untracked or ignored file, remove the line with the file. This
+  deletes the file by using the operating system's file-deletion facilities.
 * To revert changes done to a file since the last commit, remove the line with
   the file. This runs `git checkout FILE` (if the file is staged, it first runs
   `git reset FILE`).
 
 The status is case-insensitive, e.g. both `A` and `a` stage the given file
 (lower-case letters are easier to type).
+
+As with `git status`, ignored files aren't being shown by default,
+instead the flag `--ignored` has to be set.
 
 Selecting an Editor
 -------------------

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Limitations
   * `D`: Deleted file (not staged).
   * `M`: Modified file (not staged).
   * `?`: Untracked file.
+  * `!`: Ignored file.
 
 * Working with files having merge conflicts (status `U`,
   [#5](https://github.com/s3rvac/git-edit-index/issues/5)), renamed files

--- a/git-edit-index
+++ b/git-edit-index
@@ -110,6 +110,7 @@ class IndexEntry(object):
         #      M FILE    | M FILE     | modified file
         #      D FILE    | D FILE     | deleted file
         #     ?? FILE    | ? FILE     | untracked file
+        #     !! FILE    | ! FILE     | ignored file
         #
         # The script also supports the following custom status that is not
         # present in git:
@@ -130,6 +131,8 @@ class IndexEntry(object):
             return cls('D', file)
         elif re.match(r'\?', status):
             return cls('?', file)
+        elif re.match(r'\!', status):
+            return cls('!', file)
         elif re.match(r'P', status):
             return cls('P', file)
 
@@ -165,25 +168,25 @@ class NoIndexEntry(IndexEntry):
         return '- {}'.format(self.file)
 
 
-def current_index():
+def current_index(show_ignored=False):
     """Returns the current index of the git repository."""
-    return Index.from_text(git_status(), line_sep='\0')
+    return Index.from_text(git_status(show_ignored), line_sep='\0')
 
 
-def git_status():
+def git_status(show_ignored=False):
     """Returns the current status of the git repository as text, where
     individual lines are separated by the null byte.
     """
-    return subprocess.check_output(
-        # Arguments --porcelain and -z are needed to make the output
-        # parsing-friendly. They (1) cause paths to be shown relatively from
-        # the repository's root (thus disregarding user's preferences), (2) use
-        # the null byte to separate lines instead of LF, and (3) prevent
-        # formatting of special characters. See `main git-status` for more
-        # details.
-        ['git', 'status', '--porcelain', '-z'],
-        universal_newlines=True
-    )
+    # Arguments --porcelain and -z are needed to make the output
+    # parsing-friendly. They (1) cause paths to be shown relatively from
+    # the repository's root (thus disregarding user's preferences), (2) use
+    # the null byte to separate lines instead of LF, and (3) prevent
+    # formatting of special characters. See `main git-status` for more
+    # details.
+    cmd = ['git', 'status', '--porcelain', '-z']
+    if show_ignored:
+        cmd.append('--ignored')
+    return subprocess.check_output(cmd, universal_newlines=True)
 
 
 def edit_index(index):
@@ -256,7 +259,7 @@ def reflect_index_change(orig_entry, new_entry):
             perform_git_action('checkout', orig_entry.file, ignore_stderr=True)
         elif orig_entry.status in ['D', 'M']:
             perform_git_action('checkout', orig_entry.file)
-        elif orig_entry.status == '?':
+        elif orig_entry.status in ['?', '!']:
             remove(orig_entry.file)
     elif new_entry.status == 'A':
         perform_git_action('add', new_entry.file)
@@ -379,13 +382,17 @@ def parse_args(argv):
         action='version',
         version='%(prog)s {}'.format(__version__)
     )
-    parser.parse_args(argv)
+    parser.add_argument(
+        '--ignored',
+        action='store_true'
+    )
+    return parser.parse_args(argv)
 
 
 def main(argv):
-    parse_args(argv[1:])
+    args = parse_args(argv[1:])
 
-    orig_index = current_index()
+    orig_index = current_index(args.ignored)
     if not orig_index:
         # There is nothing in the index, so do not bother the user with an
         # empty editor.

--- a/git-edit-index
+++ b/git-edit-index
@@ -131,7 +131,7 @@ class IndexEntry(object):
             return cls('D', file)
         elif re.match(r'\?', status):
             return cls('?', file)
-        elif re.match(r'\!', status):
+        elif re.match(r'!', status):
             return cls('!', file)
         elif re.match(r'P', status):
             return cls('P', file)
@@ -168,12 +168,12 @@ class NoIndexEntry(IndexEntry):
         return '- {}'.format(self.file)
 
 
-def current_index(show_ignored=False):
+def current_index(show_ignored=None):
     """Returns the current index of the git repository."""
-    return Index.from_text(git_status(show_ignored), line_sep='\0')
+    return Index.from_text(git_status(show_ignored=show_ignored), line_sep='\0')
 
 
-def git_status(show_ignored=False):
+def git_status(show_ignored=None):
     """Returns the current status of the git repository as text, where
     individual lines are separated by the null byte.
     """
@@ -185,7 +185,7 @@ def git_status(show_ignored=False):
     # details.
     cmd = ['git', 'status', '--porcelain', '-z']
     if show_ignored:
-        cmd.append('--ignored')
+        cmd.append('--ignored=' + show_ignored)
     return subprocess.check_output(cmd, universal_newlines=True)
 
 
@@ -262,7 +262,7 @@ def reflect_index_change(orig_entry, new_entry):
         elif orig_entry.status in ['?', '!']:
             remove(orig_entry.file)
     elif new_entry.status == 'A':
-        perform_git_action('add', new_entry.file)
+        perform_git_action(['add', '-f'], new_entry.file)
     elif new_entry.status in ['D', 'M']:
         perform_git_action('reset', new_entry.file)
     elif new_entry.status == '?':
@@ -384,7 +384,11 @@ def parse_args(argv):
     )
     parser.add_argument(
         '--ignored',
-        action='store_true'
+        nargs='?',
+        dest='ignored',
+        const='traditional',
+        choices=('traditional', 'no', 'matching'),
+        help='Show ignored files as well.'
     )
     return parser.parse_args(argv)
 
@@ -392,7 +396,7 @@ def parse_args(argv):
 def main(argv):
     args = parse_args(argv[1:])
 
-    orig_index = current_index(args.ignored)
+    orig_index = current_index(show_ignored=args.ignored)
     if not orig_index:
         # There is nothing in the index, so do not bother the user with an
         # empty editor.

--- a/tests/git_edit_index_tests.py
+++ b/tests/git_edit_index_tests.py
@@ -293,11 +293,11 @@ class GitStatusTests(unittest.TestCase, WithPatching):
         STATUS = 'status'
         self.subprocess.check_output.return_value = STATUS
 
-        status = git_status(True)
+        status = git_status(show_ignored='traditional')
 
         self.assertEqual(status, STATUS)
         self.subprocess.check_output.assert_called_once_with(
-            ['git', 'status', '--porcelain', '-z', '--ignored'],
+            ['git', 'status', '--porcelain', '-z', '--ignored=traditional'],
             universal_newlines=True
         )
 
@@ -412,7 +412,7 @@ class ReflectIndexChangeTests(unittest.TestCase, WithPatching):
 
         reflect_index_change(orig_entry, new_entry)
 
-        self.perform_git_action.assert_called_once_with('add', 'file.txt')
+        self.perform_git_action.assert_called_once_with(['add', '-f'], 'file.txt')
 
     def test_performs_correct_action_when_untracked_file_is_to_be_deleted(self):
         orig_entry = IndexEntry('?', 'file.txt')
@@ -429,7 +429,7 @@ class ReflectIndexChangeTests(unittest.TestCase, WithPatching):
 
         reflect_index_change(orig_entry, new_entry)
 
-        self.perform_git_action.assert_called_once_with('add', 'file.txt')
+        self.perform_git_action.assert_called_once_with(['add', '-f'], 'file.txt')
 
     def test_performs_correct_action_when_ignored_file_is_to_be_deleted(self):
         orig_entry = IndexEntry('!', 'file.txt')
@@ -446,7 +446,7 @@ class ReflectIndexChangeTests(unittest.TestCase, WithPatching):
 
         reflect_index_change(orig_entry, new_entry)
 
-        self.perform_git_action.assert_called_once_with('add', 'file.txt')
+        self.perform_git_action.assert_called_once_with(['add', '-f'], 'file.txt')
 
     def test_performs_correct_action_when_modified_file_is_to_be_partially_added(self):
         orig_entry = IndexEntry('M', 'file.txt')
@@ -466,7 +466,7 @@ class ReflectIndexChangeTests(unittest.TestCase, WithPatching):
 
         reflect_index_change(orig_entry, new_entry)
 
-        self.perform_git_action.assert_called_once_with('add', 'file.txt')
+        self.perform_git_action.assert_called_once_with(['add', '-f'], 'file.txt')
 
     def test_performs_correct_action_when_deleted_file_is_to_be_partially_added(self):
         orig_entry = IndexEntry('D', 'file.txt')


### PR DESCRIPTION
I needed something smaller for the start, thus, ignored files. The test coverage is great btw.

Doesn't anything if a file is set to ignored status. What should it do? Add the verbatim filename to `.gitignore`?  Open an editor for `.gitignore` with all changed filenames added ready edit it?